### PR TITLE
Slice 2: Overlay data model, loader, and discovery

### DIFF
--- a/scripts/profile_dispatcher.py
+++ b/scripts/profile_dispatcher.py
@@ -58,6 +58,53 @@ class ResolvedProfile:
     is_kde: bool
 
 
+@dataclass(frozen=True)
+class OverlayDefinition:
+    """
+    Parsed overlay YAML file.
+
+    Attributes:
+        name: Human-readable overlay name
+        description: Optional description of what this overlay does
+        applies_when: Jinja2 expression string to evaluate if overlay applies
+        roles: List of role dicts with role name and optional annotations
+    """
+    name: str
+    description: Optional[str]
+    applies_when: str
+    roles: tuple
+
+
+@dataclass(frozen=True)
+class ResolvedOverlay:
+    """
+    Resolution output for one overlay.
+
+    Attributes:
+        name: The overlay name (filename without .yml extension)
+        applies: Whether the overlay's applies_when condition evaluated to true
+        roles: Tuple of per-role resolution results
+    """
+    name: str
+    applies: bool
+    roles: tuple
+
+
+@dataclass(frozen=True)
+class ResolvedOverlayRole:
+    """
+    Per-role result for an overlay.
+
+    Attributes:
+        role: The role name
+        tags: Tuple of tags to apply
+        applies: Whether this specific role applies
+    """
+    role: str
+    tags: tuple
+    applies: bool
+
+
 def load_profile(profiles_dir: str, name: str) -> dict:
     """
     Load a profile by name, merging its extends chain.
@@ -118,6 +165,114 @@ def _load_profile_inner(profiles_dir: str, name: str, visited: frozenset) -> dic
     parent_name = str(extends).removesuffix(".yml")
     parent_data = _load_profile_inner(profiles_dir, parent_name, visited | {name})
     return _merge_profile_data(parent_data, data)
+
+
+def load_overlay(profiles_dir: str, name: str) -> OverlayDefinition:
+    """
+    Load a single overlay YAML file by name.
+
+    Args:
+        profiles_dir: Directory containing overlay YAML files
+        name: Overlay name with or without .yml extension (e.g. 'laptop' or 'laptop.yml')
+
+    Returns:
+        OverlayDefinition with parsed overlay data
+
+    Raises:
+        ValueError: If the overlay file does not exist, path is invalid,
+                    or required fields are missing
+    """
+    name = name.removesuffix(".yml")
+
+    # Guard against path traversal: reject names with separators or parent references
+    if "/" in name or "\\" in name or ".." in name:
+        raise ValueError(
+            f"Overlay name '{name}' contains invalid path characters. "
+            "Overlay names must not include path separators or '..'."
+        )
+
+    overlays_root = Path(profiles_dir).resolve() / "overlays"
+    overlay_path = overlays_root / f"{name}.yml"
+
+    # Enforce the path stays inside overlays directory even after resolution
+    try:
+        overlay_path.resolve().relative_to(overlays_root.resolve())
+    except ValueError:
+        raise ValueError(
+            f"Overlay '{name}' resolves outside the overlays directory."
+        )
+
+    if not overlay_path.exists():
+        raise ValueError(f"Overlay '{name}' not found at {overlay_path}")
+
+    with open(overlay_path) as f:
+        data = yaml.safe_load(f) or {}
+
+    # Validate required fields
+    required_fields = ("name", "applies_when", "roles")
+    missing_fields = [f for f in required_fields if f not in data]
+    if missing_fields:
+        raise ValueError(
+            f"Overlay '{name}' is missing required fields: {', '.join(missing_fields)}"
+        )
+
+    # Extract and validate fields
+    overlay_name = data["name"]
+    if not isinstance(overlay_name, str):
+        raise ValueError(
+            f"Field 'name' in overlay '{name}' must be a string, got {type(overlay_name).__name__}"
+        )
+
+    description = data.get("description")
+    if description is not None and not isinstance(description, str):
+        raise ValueError(
+            f"Field 'description' in overlay '{name}' must be a string or null, got {type(description).__name__}"
+        )
+
+    applies_when = data["applies_when"]
+    if not isinstance(applies_when, str):
+        raise ValueError(
+            f"Field 'applies_when' in overlay '{name}' must be a string, got {type(applies_when).__name__}"
+        )
+
+    roles = data.get("roles", [])
+    if not isinstance(roles, list):
+        raise ValueError(
+            f"Field 'roles' in overlay '{name}' must be a list, got {type(roles).__name__}"
+        )
+
+    # Convert roles list to tuple for immutability
+    roles_tuple = tuple(roles)
+
+    return OverlayDefinition(
+        name=overlay_name,
+        description=description,
+        applies_when=applies_when,
+        roles=roles_tuple,
+    )
+
+
+def _discover_overlays(profiles_dir: str) -> list:
+    """
+    Discover all overlay YAML files in the overlays directory.
+
+    Args:
+        profiles_dir: Directory containing profile YAML files (overlays are in profiles_dir/overlays/)
+
+    Returns:
+        Sorted list of overlay names (without .yml extension). Empty list if overlays
+        directory does not exist or contains no YAML files.
+    """
+    overlays_root = Path(profiles_dir).resolve() / "overlays"
+
+    if not overlays_root.exists() or not overlays_root.is_dir():
+        return []
+
+    overlays = [
+        p.stem
+        for p in overlays_root.glob("*.yml")
+    ]
+    return sorted(overlays)
 
 
 def _merge_profile_data(parent: dict, child: dict) -> dict:


### PR DESCRIPTION
Closes #76

## Summary

Implemented Slice 2 of the overlay system for the Profile Dispatcher, adding data models, a secure YAML loader, and file discovery. This enables machine-specific conditional role application through declarative overlay files that live alongside profiles in `profiles/overlays/`. Overlays use Jinja2 expressions to determine applicability and can annotate roles with tags, supporting advanced configuration scenarios like laptop-specific tweaks or hardware-driven role selection.

## Implementation Approach

### Architecture

**Three new immutable dataclasses** form the overlay data model:
- `OverlayDefinition`: Parsed overlay YAML (name, description, applies_when expression, roles list)
- `ResolvedOverlay`: Resolution result (name, applies boolean, per-role outcomes)
- `ResolvedOverlayRole`: Per-role resolution (role name, tags, applies boolean)

**Loader function** `load_overlay()` provides secure YAML parsing with:
- Path traversal guards (rejects `/`, `\`, `..` in overlay names)
- Resolved path validation ensuring files stay inside overlays directory
- Schema validation for required fields (name, applies_when, roles)
- Type checking for all fields (strings, lists, nulls)

**Discovery function** `_discover_overlays()` scans `profiles_dir/overlays/*.yml` and returns sorted overlay names.

### Key Decisions

**Immutability via `@dataclass(frozen=True)`**: All overlay dataclasses are frozen to prevent accidental mutation during resolution and enable safe sharing across the codebase.

**Tuple conversion for roles**: Roles list converted to tuple in `OverlayDefinition` for hashability and to align with Python's preference for immutable sequences in dataclasses.

**Security-first validation**: Path traversal checks happen *before* any file I/O, with both character-level rejection (`/`, `\`, `..`) and post-resolution path validation. This prevents directory traversal even if symlink tricks are used.

**Graceful degradation**: `_discover_overlays()` returns empty list if overlays directory doesn't exist, enabling optional overlay support without breaking existing setups.

### Alternatives Considered

**JSON schema validation (e.g., pydantic)**: Not chosen because it adds a heavyweight dependency for simple validation. Manual type checks are sufficient for this schema and keep the module lightweight.

**Dynamic applies_when evaluation**: Not implemented in this slice—Jinja2 expression parsing is deferred to Slice 3. This slice focuses solely on data modeling and file loading.

## Changes Made

**`scripts/profile_dispatcher.py`** (+155 lines):
- Added `OverlayDefinition`, `ResolvedOverlay`, `ResolvedOverlayRole` dataclasses (lines 61-103)
- Added `load_overlay(profiles_dir, name)` function (lines 173-246)
  - Strips `.yml` suffix, validates path safety
  - Guards against path traversal attacks
  - Validates overlay file exists and is within overlays directory
  - Validates required fields (name, applies_when, roles)
  - Type-checks all fields
- Added `_discover_overlays(profiles_dir)` helper (lines 249-265)
  - Returns sorted list of overlay names from `profiles_dir/overlays/*.yml`
  - Returns empty list if directory doesn't exist

## Testing & Verification

### Automated Tests

No tests added in this slice (test coverage planned for final slice).

### Manual Verification Needed

1. Create test overlay file in `profiles/overlays/test.yml` with valid structure
2. Run `scripts/profile_dispatcher.py list-profiles` to verify discovery
3. Run with invalid overlay name containing `..` or `/` to verify path rejection
4. Create malformed overlay (missing required fields) to verify validation error messages

## Edge Cases & Limitations

### Handled

- **Path traversal**: Rejects overlay names with `/`, `\`, or `..` characters
- **Symlink escape**: Validates resolved path stays inside overlays directory
- **Missing overlays directory**: Returns empty list from `_discover_overlays()`
- **Missing required fields**: Clear error messages listing which fields are absent
- **Type mismatches**: Validates field types (string vs. list vs. null)

### Not Handled (Future Work)

- **Jinja2 expression evaluation**: `applies_when` is stored but not yet evaluated (Slice 3)
- **Role tag resolution**: Tags in roles list are stored but not yet processed (Slice 3)
- **Circular references**: Not applicable in this slice (no extends/inheritance for overlays)
- **Overlay priority/conflicts**: Not defined—assumes overlays are independent

## Security & Performance

**Security**: Path traversal guards prevent reading files outside overlays directory. All file access is scoped to `profiles_dir/overlays/`. YAML parsing uses `yaml.safe_load()` to prevent arbitrary code execution.

**Performance**: Minimal overhead—file discovery uses `Path.glob()` which is lazy. Loader reads only the requested file. No caching added yet (can be added in Slice 4 if bottlenecks emerge).

## Migration & Deployment

**No breaking changes**: This is additive functionality. Existing profiles continue to work unchanged.

**New directory structure expected**: Deployments should create `profiles/overlays/` directory (optional—if missing, overlay discovery returns empty list).

**Ansible integration pending**: Slice 4 will wire overlay resolution into the main resolver and Ansible play.yml integration.

## Follow-up Items

- **Slice 3**: Implement Jinja2 expression evaluation for `applies_when` conditions
- **Slice 3**: Add role tag resolution and merging into final role list
- **Slice 4**: Integrate overlay resolution into main `resolve_profile()` function
- **Slice 4**: Add CLI subcommand for overlay validation and listing
- **Testing**: Comprehensive unit tests for loader, discovery, and resolution logic
- **Documentation**: Overlay authoring guide with Jinja2 expression examples

---
**Generated by:** Ralph autonomous development loop (worker worker-2-2758462)
**Quality Gate:** `make validate-deps && make syntax-check` ✅