### PR TITLE
fix: address generate-playbook PR review feedback

### DIFF
--- a/scripts/profile_dispatcher.py
+++ b/scripts/profile_dispatcher.py
@@ -2053,7 +2053,7 @@ def _cmd_generate_playbook(args: argparse.Namespace) -> int:
         return 1
 
     # Output as YAML
-    yaml.dump({"roles": roles}, sys.stdout, default_flow_style=False, sort_keys=False)
+    yaml.safe_dump({"roles": roles}, sys.stdout, default_flow_style=False, sort_keys=False)
     return 0
 
 

--- a/scripts/profile_dispatcher.py
+++ b/scripts/profile_dispatcher.py
@@ -17,6 +17,7 @@ CLI subcommands:
   validate             Validate all profiles and overlays in a directory (for CI)
   list-profiles        List available profile names or a human-readable table
   make-args            Output -e flag string for Makefile consumption
+  generate-playbook    Generate Ansible playbook roles section from profile definitions
 """
 
 import argparse
@@ -1643,6 +1644,139 @@ def _resolve_manual_mode(
 
 
 # ---------------------------------------------------------------------------
+# Playbook Generation (Slice 9)
+# ---------------------------------------------------------------------------
+
+
+class PlaybookGenerator:
+    """
+    Generates Ansible playbook roles section from profile definitions.
+
+    This class encapsulates the logic for converting profile YAML files
+    into the Ansible roles section format expected by play.yml.
+    """
+
+    def __init__(self, profiles_dir: str = _DEFAULT_PROFILES_DIR) -> None:
+        """
+        Initialize the generator.
+
+        Args:
+            profiles_dir: Directory containing profile YAML files
+        """
+        self.profiles_dir = profiles_dir
+
+    def generate(self) -> list:
+        """
+        Generate the Ansible roles section from all profile definitions.
+
+        This method:
+        1. Reads all profile YAML files
+        2. Generates expected play.yml roles section using resolve_role_manifest
+        3. Merges conditions across profiles (OR differing ones)
+        4. Applies profile-gating for roles exclusive to specific DE profiles
+
+        Returns:
+            List of role entries in Ansible format (strings or dicts with role/when)
+
+        Raises:
+            ValueError: If profiles directory does not exist
+        """
+        # Validate profiles directory exists
+        profiles_path = Path(self.profiles_dir)
+        if not profiles_path.exists():
+            raise ValueError(f"Profiles directory does not exist: {profiles_path}")
+        if not profiles_path.is_dir():
+            raise ValueError(f"Profiles path is not a directory: {profiles_path}")
+
+        profile_names = list_profiles(self.profiles_dir)
+
+        # --- Profile-gating inference ---
+        # DE profiles and their corresponding _is_<de> flags
+        de_profiles = {"i3", "hyprland", "gnome", "awesomewm", "kde"}
+        profile_to_flag = {
+            "i3": "_is_i3",
+            "hyprland": "_is_hyprland",
+            "gnome": "_is_gnome",
+            "awesomewm": "_is_awesomewm",
+            "kde": "_is_kde",
+        }
+
+        # Track which profiles include each role AND build annotation conditions
+        role_to_profiles: Dict[str, set] = {}
+        expected_role_map: Dict[str, Optional[str]] = {}
+
+        for profile_name in profile_names:
+            try:
+                manifest = resolve_role_manifest(
+                    profile=profile_name,
+                    os_family="Archlinux",
+                    host_vars={},
+                    profiles_dir=self.profiles_dir,
+                    preserve_config_check=True,
+                )
+            except ValueError:
+                continue
+
+            for role_cond in manifest.roles:
+                role_name = role_cond.role
+                condition = role_cond.condition or None
+
+                # Track profile membership
+                role_to_profiles.setdefault(role_name, set()).add(profile_name)
+
+                # Merge conditions across profiles (OR differing ones)
+                if role_name not in expected_role_map:
+                    expected_role_map[role_name] = condition
+                    continue
+
+                existing_condition = expected_role_map[role_name]
+                if existing_condition is None or condition is None:
+                    expected_role_map[role_name] = None
+                elif existing_condition != condition:
+                    expected_role_map[role_name] = (
+                        f"({existing_condition}) or ({condition})"
+                    )
+
+        # Apply profile-gating for roles with empty annotation conditions
+        all_profile_set = set(profile_names)
+        for role_name, profiles in role_to_profiles.items():
+            existing = expected_role_map.get(role_name)
+            # Only add profile gate if annotation-based condition is empty
+            if existing is not None:
+                continue
+
+            # Universal roles (in ALL profiles including headless) need no gate
+            if profiles >= all_profile_set:
+                continue
+
+            de_members = profiles & de_profiles
+            if not de_members:
+                continue
+
+            # Determine the profile gate expression
+            if de_members == de_profiles:
+                gate = "_has_display"
+            elif len(de_members) == 1:
+                gate = profile_to_flag[next(iter(de_members))]
+            else:
+                gate = " or ".join(
+                    profile_to_flag[p] for p in sorted(de_members)
+                )
+
+            expected_role_map[role_name] = gate
+
+        # Build the roles list in Ansible format
+        roles = []
+        for role_name, condition in sorted(expected_role_map.items()):
+            if condition:
+                roles.append({"role": role_name, "when": condition})
+            else:
+                roles.append(role_name)
+
+        return roles
+
+
+# ---------------------------------------------------------------------------
 # CLI subcommands
 # ---------------------------------------------------------------------------
 
@@ -1902,6 +2036,25 @@ def _cmd_resolve_role_manifest(args: argparse.Namespace) -> int:
     print(json.dumps(output, indent=2))
     return 0
 
+
+
+def _cmd_generate_playbook(args: argparse.Namespace) -> int:
+    """
+    Generate Ansible playbook roles section from profile definitions.
+
+    Outputs valid Ansible YAML to stdout representing the roles section
+    that should be in play.yml based on all profile definitions.
+    """
+    try:
+        generator = PlaybookGenerator(profiles_dir=args.profiles_dir)
+        roles = generator.generate()
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    # Output as YAML
+    yaml.dump({"roles": roles}, sys.stdout, default_flow_style=False, sort_keys=False)
+    return 0
 
 
 def _cmd_sync_playbook(args: argparse.Namespace) -> int:
@@ -2282,6 +2435,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--profiles-dir", dest="profiles_dir", default=_DEFAULT_PROFILES_DIR
     )
 
+    # --- generate-playbook ---
+    p_generate = subparsers.add_parser(
+        "generate-playbook",
+        help="Generate Ansible playbook roles section from profile definitions.",
+    )
+    p_generate.add_argument(
+        "--profiles-dir", dest="profiles_dir", default=_DEFAULT_PROFILES_DIR
+    )
+
     return parser
 
 
@@ -2310,6 +2472,7 @@ def main(argv: Optional[list] = None) -> int:
         "validate": _cmd_validate,
         "list-profiles": _cmd_list_profiles,
         "make-args": _cmd_make_args,
+        "generate-playbook": _cmd_generate_playbook,
     }
     return dispatch[args.subcommand](args)
 

--- a/scripts/profile_dispatcher.py
+++ b/scripts/profile_dispatcher.py
@@ -2361,10 +2361,14 @@ def _cmd_resolve_role_manifest(args: argparse.Namespace) -> int:
 
 def _cmd_generate_playbook(args: argparse.Namespace) -> int:
     """
-    Generate Ansible playbook roles section from profile definitions.
+    Generate the profile-derived Ansible roles mapping.
 
-    Outputs valid Ansible YAML to stdout representing the roles section
-    that should be in play.yml based on all profile definitions.
+    Outputs YAML to stdout as a top-level mapping with a single ``roles:``
+    key. This is intended for comparison with, or embedding into, the roles
+    portion of ``play.yml``; it is not a complete play definition.
+
+    Overlay-driven roles are intentionally excluded by default because this
+    generator runs without host vars.
     """
     try:
         generator = PlaybookGenerator(profiles_dir=args.profiles_dir)

--- a/scripts/profile_dispatcher.py
+++ b/scripts/profile_dispatcher.py
@@ -2377,7 +2377,7 @@ def _cmd_generate_playbook(args: argparse.Namespace) -> int:
         print(str(exc), file=sys.stderr)
         return 1
 
-    # Convert PlaybookRole tuples to Ansible-format dicts
+    # Convert PlaybookRole dataclass instances to Ansible-format dicts
     role_entries = []
     for r in roles:
         entry: Dict[str, Any] = {"role": r.role}

--- a/tests/test_profile_dispatcher.py
+++ b/tests/test_profile_dispatcher.py
@@ -2519,10 +2519,18 @@ class TestCLIGeneratePlaybook:
         rc = main(["generate-playbook"])
         out = capsys.readouterr().out
         assert rc == 0
-        # Should be valid YAML with roles key
-        assert "roles:" in out
-        # Should contain some expected roles
-        assert "shell:" in out or "- shell" in out or "- base" in out
+        parsed = yaml.safe_load(out)
+        assert isinstance(parsed, dict)
+        assert "roles" in parsed
+        assert isinstance(parsed["roles"], list)
+        assert any(
+            (
+                role == "shell"
+                or role == "base"
+                or (isinstance(role, dict) and role.get("role") in {"shell", "base"})
+            )
+            for role in parsed["roles"]
+        )
 
     def test_generate_playbook_with_custom_profiles_dir(self, capsys):
         """generate-playbook with --profiles-dir should use that directory."""

--- a/tests/test_profile_dispatcher.py
+++ b/tests/test_profile_dispatcher.py
@@ -2950,9 +2950,10 @@ class TestCLIGeneratePlaybook:
     def test_generate_playbook_bad_dir_exits_1(self, capsys):
         """generate-playbook with nonexistent profiles-dir exits 1."""
         rc = main(["generate-playbook", "--profiles-dir", "/nonexistent/path"])
-        err = capsys.readouterr().err
+        captured = capsys.readouterr()
         assert rc == 1
-        assert "does not exist" in err
+        assert captured.out == ""
+        assert "does not exist" in captured.err
 
 
 if __name__ == '__main__':

--- a/tests/test_profile_dispatcher.py
+++ b/tests/test_profile_dispatcher.py
@@ -47,6 +47,7 @@ from profile_dispatcher import (
     ConditionTranslator,
     AnsibleConditionTranslator,
     DefaultTranslator,
+    PlaybookGenerator,
 )
 
 # Path to the real profiles directory used in integration-style tests
@@ -2472,6 +2473,95 @@ class TestConditionTranslatorProtocol:
         result = translator.translate_annotation(annotation, {})
         # With preserve_config_check=True, the expression is kept as-is
         assert result == "dotfiles is defined"
+class TestPlaybookGenerator:
+    """Tests for PlaybookGenerator.generate() method."""
+
+    def test_generate_returns_list(self):
+        """generate() should return a list of role entries."""
+        generator = PlaybookGenerator(profiles_dir=_PROFILES_DIR)
+        roles = generator.generate()
+        assert isinstance(roles, list)
+
+    def test_generate_contains_role_names(self):
+        """generate() should include expected role names."""
+        generator = PlaybookGenerator(profiles_dir=_PROFILES_DIR)
+        roles = generator.generate()
+        role_names = []
+        for role in roles:
+            if isinstance(role, str):
+                role_names.append(role)
+            else:
+                role_names.append(role["role"])
+        # Some universal roles should always be present
+        assert "shell" in role_names
+        assert "base" in role_names
+
+    def test_generate_includes_conditions(self):
+        """generate() should include 'when' conditions for conditional roles."""
+        generator = PlaybookGenerator(profiles_dir=_PROFILES_DIR)
+        roles = generator.generate()
+        # At least some roles should have conditions
+        conditional_roles = [r for r in roles if isinstance(r, dict)]
+        assert len(conditional_roles) > 0
+
+    def test_generate_invalid_profiles_dir_raises_error(self):
+        """generate() should raise ValueError for non-existent profiles directory."""
+        generator = PlaybookGenerator(profiles_dir="/nonexistent/path")
+        with pytest.raises(ValueError, match="Profiles directory does not exist"):
+            generator.generate()
+
+
+class TestCLIGeneratePlaybook:
+    """Tests for the 'generate-playbook' CLI subcommand."""
+
+    def test_generate_playbook_outputs_valid_yaml(self, capsys):
+        """generate-playbook should output valid YAML with roles section."""
+        rc = main(["generate-playbook"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        # Should be valid YAML with roles key
+        assert "roles:" in out
+        # Should contain some expected roles
+        assert "shell:" in out or "- shell" in out or "- base" in out
+
+    def test_generate_playbook_with_custom_profiles_dir(self, capsys):
+        """generate-playbook with --profiles-dir should use that directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create _base.yml (required by all profiles)
+            base_path = Path(tmpdir, "_base.yml")
+            base_path.write_text("""
+name: base
+roles:
+  - role: base
+""")
+            # Create a simple profile with proper structure
+            profile_path = Path(tmpdir, "test.yml")
+            profile_path.write_text("""
+name: test
+extends: _base.yml
+display_manager_default: ""
+desktop_environment: ""
+roles:
+  - role: test_role
+""")
+            rc = main(["generate-playbook", "--profiles-dir", tmpdir])
+            out = capsys.readouterr().out
+            assert rc == 0
+            assert "test_role" in out
+
+    def test_generate_playbook_invalid_dir_exits_1(self, capsys):
+        """generate-playbook should exit 1 and write error to stderr for invalid dir."""
+        rc = main(["generate-playbook", "--profiles-dir", "/nonexistent/path"])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "Profiles directory does not exist" in err
+
+    def test_generate_playbook_outputs_to_stdout_not_stderr(self, capsys):
+        """generate-playbook should write YAML to stdout, not stderr."""
+        main(["generate-playbook"])
+        captured = capsys.readouterr()
+        assert captured.out  # stdout should not be empty
+        assert captured.err == ""  # stderr should be empty
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Two review findings from the `generate-playbook` CLI subcommand PR addressed:

- **Docstring clarity**: `_cmd_generate_playbook` docstring now explicitly states the output is a top-level `roles:` mapping (not a complete play definition) and that overlay-driven roles are intentionally excluded since the generator runs without host vars.
- **Error-path test**: `test_generate_playbook_bad_dir_exits_1` adds `assert captured.out == ""` to enforce stdout/stderr separation — stdout must be clean when the command fails.