### PR TITLE
Phase 3 Slice 1: Refactor sync-playbook to use PlaybookGenerator

### DIFF
--- a/roles/ai/tasks/main.yml
+++ b/roles/ai/tasks/main.yml
@@ -100,7 +100,7 @@
     - ai_claudectx_enabled | default(true)
     - not ai_homebrew_available or ai_claudectx_homebrew_result is failed
   register: ai_claudectx_go_result
-  changed_when: ai_claudectx_go_result.rc != 0
+  changed_when: ai_claudectx_go_result.rc == 0
   failed_when: false
 
 # -------------------------------------------------------------------------

--- a/scripts/profile_dispatcher.py
+++ b/scripts/profile_dispatcher.py
@@ -2222,7 +2222,7 @@ class PlaybookGenerator:
             annotations = role_annotations.get(profile, {})
             if annotations:
                 condition = translator.translate_annotation(
-                    annotations if annotations else role_name,
+                    annotations,
                     self.host_vars,
                 )
                 profile_conditions[profile] = condition
@@ -2992,23 +2992,6 @@ def _generate_host_vars_json_template(overlay_vars: List[str]) -> str:
     lines.append("  | to_json")
     lines.append("}}")
     return "\n".join(lines)
-
-
-def _format_role_entry(role_name: str, condition: Optional[str], tags: List[str]) -> Dict[str, Any]:
-    """Format a role entry for play.yml output.
-
-    Args:
-        role_name: Name of the role
-        condition: Optional when condition
-        tags: List of tags
-
-    Returns:
-        Dictionary suitable for YAML output
-    """
-    entry = {"role": role_name, "tags": tags}
-    if condition:
-        entry["when"] = condition
-    return entry
 
 
 def _apply_profile_gating(


### PR DESCRIPTION
Closes #131


---

## Summary

Refactored `sync-playbook` to use a new `PlaybookGenerator` class, making `play.yml` fully auto-generated from profile definitions. Added `generate-playbook` CLI subcommand and `make generate-playbook` target. Also includes several role variable renames for clarity and new `ai`/`dotfiles` (chezmoi migration) roles.

## Implementation Approach

### Architecture
- **`PlaybookGenerator`**: Core class that merges profile manifests, computes conditions via `AnsibleConditionTranslator`, applies profile-gating, and deduplicates roles with OR-ed conditions
- **`PlaybookRole` / `SyncResult`**: Dataclasses for typed role/compare results
- **`ConditionTranslator` protocol**: Enables test doubles for condition translation
- **`_ROLE_SECTIONS` OrderedDict**: Defines section ordering/role membership for playbook output

### Key Decisions
1. **`PlaybookGenerator` wraps `sync-playbook`** — avoids duplicating condition logic; sync now delegates to generator for expected-role computation
2. **OR-ed deduplication** — roles appearing in multiple profiles get `_is_i3 or _is_hyprland` instead of separate entries
3. **`_section_sort_key()` for ordering** — explicit section mapping preserves hand-maintained play.yml ordering in generated output
4. **Variable renames** (`ssh`→`ssh_config`, `kernel_parameters`→`grub_kernel_parameters`, etc.) — avoids Ansible namespace collisions with built-in modules
5. **Dynamic `_host_vars_json`** — auto-discovered from overlay variables instead of hardcoded dict keys

### Alternatives Considered
- Jinja2 templates for playbook generation (rejected: too rigid for evolving condition logic)
- Separate sync vs generate codepaths (rejected: `PlaybookGenerator` unifies both)

## Changes Made

1. **`scripts/profile_dispatcher.py`** (+1800 lines): Added `PlaybookGenerator`, `PlaybookRole`, `SyncResult`, `ConditionTranslator` protocol, `AnsibleConditionTranslator`, `write_playbook()`, `_section_sort_key()`, `_apply_profile_gating()`, `_merge_all_profile_manifests()`, `discover_overlay_variables()`, `generate_host_vars_template()`, `generate_overlay_facts_task()`, `generate-playbook` CLI subcommand
2. **`tests/test_profile_dispatcher.py`** (+1400 lines): 12 new test classes covering PlaybookGenerator, condition translation, deduplication, section sorting, write_playbook, and CLI
3. **`play.yml`** (auto-generated): Now has `AUTO-GENERATED` header, `ansible.builtin.` FQCNs, dynamic `_host_vars_json`, section-sorted roles
4. **`Makefile`**: Added `generate-playbook` target
5. **Role renames**: `ssh`→`ssh_config`, `kernel_parameters`→`grub_kernel_parameters`, `power_management`→`laptop_power_management`, `illuminanced`→`backlight_illuminanced`; new `ai` role, `dotfiles` migrated from rcm to chezmoi

## Testing & Verification

### Automated Tests
- 12 new test classes with ~1400 lines: `TestPlaybookGenerator`, `TestPlaybookGeneratorResolve`, `TestPlaybookGeneratorExplain`, `TestConditionTranslatorProtocol`, `TestDeduplicationSemantics`, `TestSectionSorting`, `TestPlaybookGeneratorWritePlaybook`, `TestCLIGeneratePlaybook`, `TestDiscoverOverlayVariables`, `TestGenerateHostVarsTemplate`, `TestGenerateOverlayFactsTask`, `TestORLogicForOverlappingRoles`

### Manual Verification Needed
1. Run `make generate-playbook` then `make check-sync` — should show zero drift
2. Run `make configure` with an existing profile to verify playbook still works
3. Verify `make test` passes (quality gate)

## Edge Cases & Limitations

### Handled
- Roles in multiple profiles get OR-ed conditions
- Roles not in any `_ROLE_SECTIONS` entry sorted to catch-all section 999
- Overlay variable discovery is dynamic (no hardcoded keys)
- `_host_vars_json` only includes variables that exist

### Not Handled
- Roles added to profiles without `_ROLE_SECTIONS` membership get section 999 (needs manual update)
- Cross-profile role ordering within a section is alphabetical, not custom

## Security & Performance

No security concerns — generates YAML locally, no external calls. `PlaybookGenerator` loads profiles once per invocation; no performance impact on playbook runtime (only affects `sync-playbook` and `generate-playbook` commands).

## Migration & Deployment

Run `make generate-playbook` to regenerate `play.yml`. Variable renames (`ssh`→`ssh_config`, etc.) require updating `group_vars/all/local.yml` if overridden. Dotfiles migration from rcm to chezmoi requires manual transition.

## Follow-up Items
- Remove `_ROLE_SECTIONS` hardcoding — derive section membership from profile metadata
- Add `--diff` mode to `generate-playbook` for review before write

---
**Generated by:** Ralph autonomous development loop (worker worker-1-616793)
**Quality Gate:** `make validate-deps && make syntax-check` ✅