### PR TITLE
feat(goesimage): refresh betterlockscreen cache from satellite wallpaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,48 @@ make configure TAGS="gpu_drivers"
 make gpu-info
 ```
 
+## Fingerprint Unlock
+
+i3 + betterlockscreen supports unlocking with the fingerprint sensor (fprintd).
+The lock wrapper (`~/.local/bin/lock-fingerprint`, managed by chezmoi in the
+dotfiles repo) runs `fprintd-verify` alongside i3lock and unlocks on a
+successful scan; typing your password still works. It is bound to
+`$mod+Shift+x` and is used by the idle auto-lock (xidlehook).
+
+> Why a wrapper instead of PAM: i3lock only starts its PAM conversation after
+> you press Enter, so `pam_fprintd` never runs. The wrapper performs the
+> equivalent authentication itself.
+
+The goesimage role deploys a systemd drop-in
+(`~/.config/systemd/user/goesimage.service.d/override.conf`) that re-renders
+the betterlockscreen cache from the current satellite wallpaper every time
+goesimage updates it.
+
+### Adding a new fingerprint
+
+Enrollment requires an **active graphical session** and a running polkit
+authentication agent (the i3 config autostarts
+`/usr/lib/polkit-kde-authentication-agent-1`); a password prompt appears
+before enrollment begins.
+
+```sh
+# List enrolled fingers
+fprintd-list "$USER"
+
+# Enroll a finger (touch the sensor repeatedly until "enroll-completed")
+fprintd-enroll                       # defaults to right-index-finger
+fprintd-enroll -f left-thumb         # or name any other finger
+
+# Delete one and re-enroll
+fprintd-delete "$USER" right-index-finger
+
+# Verify a scan without locking
+fprintd-verify
+```
+
+If enrollment fails with `PermissionDenied: Not Authorized`, your session is
+not active or no polkit agent is running — start the agent and retry.
+
 ## Requirements
 
 - Python 3

--- a/roles/goesimage/handlers/main.yml
+++ b/roles/goesimage/handlers/main.yml
@@ -5,3 +5,13 @@
     name: "goesimage@{{ user.name }}.timer"
     state: restarted
   when: goesimage.run_on == "all"
+
+- name: Reload user systemd config
+  become: true
+  become_user: "{{ user.name }}"
+  ansible.builtin.systemd:
+    scope: user
+    daemon_reload: true
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ user.uid }}"
+  when: goesimage.run_on == "all"

--- a/roles/goesimage/tasks/main.yml
+++ b/roles/goesimage/tasks/main.yml
@@ -29,6 +29,16 @@
     - reload systemd config
     - Restart GOESImage
 
+- name: Push betterlockscreen cache-refresh drop-in
+  ansible.builtin.template:
+    src: goesimage-betterlockscreen.conf.j2
+    dest: "/home/{{ user.name }}/.config/systemd/user/goesimage.service.d/override.conf"
+    mode: '0644'
+  become: true
+  become_user: "{{ user.name }}"
+  notify:
+    - Reload user systemd config
+
 - name: Enable and start goesimage.timer for user
   ansible.builtin.systemd:
     name: goesimage.timer

--- a/roles/goesimage/templates/goesimage-betterlockscreen.conf.j2
+++ b/roles/goesimage/templates/goesimage-betterlockscreen.conf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+# After goesimage writes latest.jpg, re-render the betterlockscreen cache
+# from it so the lock screen shows the current satellite image.
+# Only the "dim" effect is rendered to keep the per-run CPU cost low.
+[Service]
+ExecStartPost=/usr/bin/betterlockscreen -u /home/{{ user.name }}/.cache/goesimage/latest.jpg --fx dim


### PR DESCRIPTION
## What

- **goesimage role**: deploy a user systemd drop-in (`~/.config/systemd/user/goesimage.service.d/override.conf`) that runs `betterlockscreen -u ~/.cache/goesimage/latest.jpg --fx dim` after each goesimage run, so the lock screen shows the live GOES satellite wallpaper. Rendering only the `dim` effect keeps the per-run cost at ~8s (vs ~16s for all variants).
- **README**: new `## Fingerprint Unlock` section — documents the lock-fingerprint wrapper (chezmoi-managed), why PAM can't be used with i3lock, and how to enroll/list/delete fingers with fprintd (requires active session + polkit agent).

## Verified locally

- Drop-in deployed and exercised: cache re-renders with only `lock_dim.png` on each timer run
- `ansible-lint roles/goesimage` passes (production profile)
- `make syntax-check validate-profiles check-sync` pass
- Lock wrapper verified end-to-end: fingerprint unlock, password unlock, no spurious matches, no lingering processes